### PR TITLE
Bump helm to v2.12.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:latest
 LABEL io.openshift.s2i.scripts-url=image:///usr/libexec/s2i \
       io.openshift.s2i.assemble-user=65534:0
 
-ENV HELM_VERSION=v2.12.0 \
+ENV HELM_VERSION=v2.12.2 \
     HELM_HOME=/helm
 
 # `git` is used during CI/CD processes


### PR DESCRIPTION
To fix the security vulnerability [1].

[1] https://helm.sh/blog/helm-security-notice-2019/index.html