### PR TITLE
Bump versions: helm (< 3.x), helmfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ FROM docker.io/library/alpine:3.10@sha256:e4355b66995c96b4b468159fc5c7e3540fcef9
 LABEL io.openshift.s2i.scripts-url=image:///usr/libexec/s2i \
       io.openshift.s2i.assemble-user=65534:0
 
-ENV HELM_VERSION=v2.14.3 \
+ENV HELM_VERSION=v2.16.1 \
     HELM_HOME=/helm \
-    HELMFILE_VERSION=v0.85.3 \
+    HELMFILE_VERSION=v0.92.0 \
     SOPS_VERSION=3.4.0
 
 # `git` is used during CI/CD processes

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 The built images are available from [Docker Hub][hub]
 
-The main goal of this project is to provide a container image that can be used in CI/CD pipelines to deploy apps using [Helm][], the Kubernetes package manager.
+Provides a container image that can be used in CI/CD pipelines to deploy apps using [Helm][], the Kubernetes package manager.
 
 ## Contents
 
@@ -32,4 +32,6 @@ The main goal of this project is to provide a container image that can be used i
 
 ## Build the image
 
-    docker-compose up --build
+```console
+docker-compose build
+```


### PR DESCRIPTION
Updates helm to the latest version below v3.x (which is not backwards compatible).