### PR TITLE
Fix and enhance build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # container-helm
 
-[![Docker Build Status](https://img.shields.io/docker/build/appuio/helm.svg)](https://hub.docker.com/r/appuio/helm/)
+[![dockeri.co](http://dockeri.co/image/appuio/helm)](https://hub.docker.com/r/appuio/helm/)
+
+[![Build Status](https://img.shields.io/docker/cloud/build/appuio/helm.svg)](https://hub.docker.com/r/appuio/helm/builds
+) [![GitHub issues](https://img.shields.io/github/issues-raw/appuio/container-helm.svg)](https://github.com/appuio/container-helm/issues
+) [![GitHub PRs](https://img.shields.io/github/issues-pr-raw/appuio/container-helm.svg)](https://github.com/appuio/container-helm/pulls
+) [![License](https://img.shields.io/github/license/appuio/container-helm.svg)](https://github.com/appuio/container-helm/blob/master/LICENSE)
+
 
 `helm` in a container image.
 


### PR DESCRIPTION
I know you don't like the large Docker image badge, but let's make the top of the README both

* a little bit more informative :smiley: 
* and uniform across all our repos. :roll_eyes: 

The badge against the docker cloud doesn't seem to have the flaw of the current build badge.